### PR TITLE
feat(analysis): 为 compute_future_return 函数添加 direction 参数

### DIFF
--- a/test/test_indicators.py
+++ b/test/test_indicators.py
@@ -175,7 +175,7 @@ def test_compute_future_return_future_days_2():
     df = pd.DataFrame({"price": [100.0, 110.0, 120.0, 130.0, 140.0]}, index=dates)
 
     # 设定 future_days = 2
-    result = compute_future_return(df, future_days=2)
+    result = compute_future_return(df, future_days=2, direction='long')
 
     # 计算说明：
     # 对于 future_days = 2：
@@ -220,7 +220,7 @@ def test_compute_future_return_future_days_1():
     df = pd.DataFrame({"price": prices}, index=dates)
 
     # 设定 future_days = 1
-    result = compute_future_return(df, future_days=1)
+    result = compute_future_return(df, future_days=1, direction='long')
 
     # 对于 future_days = 1：
     #   index 0: future_return = (220/200 - 1) = 0.1

--- a/utils/analysis.py
+++ b/utils/analysis.py
@@ -300,7 +300,7 @@ def indicator_ma_discovery(
 
         for ma in mas:
             df_bias_slice = df_bias[['indicator', 'price', 'ma' + str(ma), 'ma' + str(ma) + '_bias']].copy()
-            df_bias_slice = compute_future_return(df=df_bias_slice, future_days=ma)
+            df_bias_slice = compute_future_return(df=df_bias_slice, future_days=ma, direction='long')
             group_dfs = group_data(
                 df=df_bias_slice,
                 group_by="bias",


### PR DESCRIPTION
- 在 compute_future_return 函数中添加 direction 参数，支持做多和做空两种方向
- 修改 analysis.py 中调用 compute_future_return 函数，指定 direction 为 'long'- 更新 test_indicators.py 中的测试用例，明确指定 direction为 'long'